### PR TITLE
CopyFromGit fails if file has been deleted

### DIFF
--- a/src/main/java/tdl/record/sourcecode/content/CopyFromDirectorySourceCodeProvider.java
+++ b/src/main/java/tdl/record/sourcecode/content/CopyFromDirectorySourceCodeProvider.java
@@ -1,24 +1,10 @@
 package tdl.record.sourcecode.content;
 
-import java.io.File;
 import org.apache.commons.io.FileUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.commons.io.filefilter.IOFileFilter;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.Status;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.errors.NoWorkTreeException;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.revwalk.DepthWalk.RevWalk;
-import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevTree;
-import org.eclipse.jgit.treewalk.TreeWalk;
 import tdl.record.sourcecode.snapshot.helpers.ExcludeGitDirectoryFileFilter;
 import tdl.record.sourcecode.snapshot.helpers.GitHelper;
 

--- a/src/main/java/tdl/record/sourcecode/content/CopyFromGitSourceCodeProvider.java
+++ b/src/main/java/tdl/record/sourcecode/content/CopyFromGitSourceCodeProvider.java
@@ -1,5 +1,6 @@
 package tdl.record.sourcecode.content;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
@@ -41,7 +42,7 @@ public class CopyFromGitSourceCodeProvider implements SourceCodeProvider {
 
         while (treeWalk.next()) {
             String path = treeWalk.getPathString();
-            copyFile(srcPath, destPath, path);
+            copyFileIfExists(srcPath, destPath, path);
         }
     }
 
@@ -52,7 +53,7 @@ public class CopyFromGitSourceCodeProvider implements SourceCodeProvider {
             status = git.status().call();
             status.getUntracked().stream().forEach((path) -> {
                 try {
-                    copyFile(srcPath, destPath, path);
+                    copyFileIfExists(srcPath, destPath, path);
                 } catch (IOException ex) {
                     //Do nothing
                 }
@@ -62,10 +63,12 @@ public class CopyFromGitSourceCodeProvider implements SourceCodeProvider {
         }
     }
 
-    private static void copyFile(Path srcPath, Path destPath, String path) throws IOException {
-        Path destFile = destPath.resolve(path);
-        Path srcFile = srcPath.resolve(path);
-        FileUtils.copyFile(srcFile.toFile(), destFile.toFile());
+    private static void copyFileIfExists(Path srcPath, Path destPath, String path) throws IOException {
+        File srcFile = srcPath.resolve(path).toFile();
+        if (srcFile.exists()) {
+            File destFile = destPath.resolve(path).toFile();
+            FileUtils.copyFile(srcFile, destFile);
+        }
     }
 
     private static TreeWalk createTreeWalkForCopying(Repository repo) throws IOException {

--- a/src/test/java/tdl/record/sourcecode/content/CopyFromDirectorySourceCodeProviderTest.java
+++ b/src/test/java/tdl/record/sourcecode/content/CopyFromDirectorySourceCodeProviderTest.java
@@ -48,6 +48,28 @@ public class CopyFromDirectorySourceCodeProviderTest {
         assertFalse(exists(actual, ".git"));
     }
 
+    @Test
+    public void retrieveAndSaveToShouldWorkWithDeletedFiles() throws IOException, GitAPIException {
+        File original = folder.newFolder();
+        Path originalPath = original.toPath();
+        File actual = folder.newFolder();
+
+        Git git = Git.init().setDirectory(original).call();
+        FileTestHelper.appendStringToFile(originalPath, "file.to.keep.txt", "TEST2");
+        FileTestHelper.appendStringToFile(originalPath, "file.to.remove.txt", "TEST1");
+        git.add().addFilepattern(".").call();
+        git.commit().setMessage("commit1").call();
+
+        FileTestHelper.deleteFile(originalPath, "file.to.remove.txt");
+
+        CopyFromDirectorySourceCodeProvider provider = new CopyFromDirectorySourceCodeProvider(originalPath);
+        provider.retrieveAndSaveTo(actual.toPath());
+
+        assertTrue(exists(actual, "file.to.keep.txt"));
+        assertFalse(exists(actual, "file.to.remove.txt"));
+    }
+
+
     private boolean exists(File parent, String path) {
         return Files.exists(parent.toPath().resolve(path));
     }


### PR DESCRIPTION
If the target folder is a Git repo and a file previously commited is removed, the tree walk and copy will fail.
I have added a failing test.