### PR TITLE
Fix issue with jgit patience algo config

### DIFF
--- a/src/main/java/tdl/record/sourcecode/snapshot/helpers/GitHelper.java
+++ b/src/main/java/tdl/record/sourcecode/snapshot/helpers/GitHelper.java
@@ -27,6 +27,8 @@ public class GitHelper {
 
     private static String ARCHIVE_FORMAT_ZIP = "zip";
 
+    private static final String FALLBACK_DIFF_ALGORITHM = DiffAlgorithm.SupportedAlgorithm.HISTOGRAM.toString().toLowerCase();
+
     public static boolean isGitDirectory(Path path) {
         File directory = path.toFile();
         FileRepositoryBuilder builder = new FileRepositoryBuilder();
@@ -48,10 +50,7 @@ public class GitHelper {
 
     public static void exportDiff(Git git, OutputStream outputStream) throws Exception {
         Repository repository = git.getRepository();
-        fixDiffAlgorithmIfNotSupported(
-                repository,
-                DiffAlgorithm.SupportedAlgorithm.HISTOGRAM.toString().toLowerCase()
-        );
+        fixDiffAlgorithmIfNotSupported(repository);
 
         ObjectId oldHead = repository.resolve("HEAD^^{tree}");
         ObjectId head = repository.resolve("HEAD^{tree}");
@@ -74,8 +73,7 @@ public class GitHelper {
 
     }
 
-    private static void fixDiffAlgorithmIfNotSupported(Repository repository,
-                                                       String fallbackDiffAlgorithm) throws IOException, ConfigInvalidException {
+    private static void fixDiffAlgorithmIfNotSupported(Repository repository) throws IOException, ConfigInvalidException {
         repository.getConfig().load();
         String configuredDiffAlgorithm = repository
                 .getConfig()
@@ -98,7 +96,7 @@ public class GitHelper {
                         ConfigConstants.CONFIG_DIFF_SECTION,
                         null,
                         ConfigConstants.CONFIG_KEY_ALGORITHM,
-                        fallbackDiffAlgorithm
+                        FALLBACK_DIFF_ALGORITHM
                 );
 
                 System.out.println("Warning: local or global git config file is set to use an unsupported diff algorithm: " + configuredDiffAlgorithm);

--- a/src/main/java/tdl/record/sourcecode/snapshot/helpers/GitHelper.java
+++ b/src/main/java/tdl/record/sourcecode/snapshot/helpers/GitHelper.java
@@ -85,16 +85,25 @@ public class GitHelper {
                         ConfigConstants.CONFIG_KEY_ALGORITHM
                 );
 
-        if ("patience".equals(configuredDiffAlgorithm)) {
-            repository.getConfig().setString(
-                    ConfigConstants.CONFIG_DIFF_SECTION,
-                    null,
-                    ConfigConstants.CONFIG_KEY_ALGORITHM,
-                    fallbackDiffAlgorithm
-            );
-            
-            System.out.println("Warning: local or global git config file is set to use an unsupported diff algorithm: " + configuredDiffAlgorithm);
-            System.out.println("It has been overridden to use the 'histogram' diff algorithm.");
+        DiffAlgorithm.SupportedAlgorithm supportedAlgorithm = null;
+        try {
+            if (configuredDiffAlgorithm != null) {
+                supportedAlgorithm = DiffAlgorithm.SupportedAlgorithm.valueOf(configuredDiffAlgorithm.toUpperCase());
+            }
+        } catch (IllegalArgumentException ex) {
+            // do nothing - means git config might has been set to an unsupported diff algorithm
+        } finally {
+            if (supportedAlgorithm == null) {
+                repository.getConfig().setString(
+                        ConfigConstants.CONFIG_DIFF_SECTION,
+                        null,
+                        ConfigConstants.CONFIG_KEY_ALGORITHM,
+                        fallbackDiffAlgorithm
+                );
+
+                System.out.println("Warning: local or global git config file is set to use an unsupported diff algorithm: " + configuredDiffAlgorithm);
+                System.out.println("It has been overridden to use the 'histogram' diff algorithm.");
+            }
         }
     }
 

--- a/src/test/java/tdl/record/sourcecode/snapshot/helpers/DiffAlgoPatienceJGitIssueTest.java
+++ b/src/test/java/tdl/record/sourcecode/snapshot/helpers/DiffAlgoPatienceJGitIssueTest.java
@@ -1,0 +1,125 @@
+package tdl.record.sourcecode.snapshot.helpers;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.util.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import tdl.record.sourcecode.test.FileTestHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static tdl.record.sourcecode.snapshot.helpers.GitHelper.addAndCommit;
+
+public class DiffAlgoPatienceJGitIssueTest {
+
+    private File directory;
+    private Git git;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException, GitAPIException {
+        directory = folder.newFolder();
+        git = Git.init().setDirectory(directory).call();
+        Repository repository = git.getRepository();
+        repository.getConfig().setString(
+            ConfigConstants.CONFIG_DIFF_SECTION,
+            null,
+            ConfigConstants.CONFIG_KEY_ALGORITHM,
+            "patience");
+    }
+
+    @Test
+    public void exportPatchAndApply() throws Exception {
+        addAndCommit(git);
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            GitHelper.exportDiff(git, os);
+            assertTrue(os.toByteArray().length == 0);
+        }
+
+        FileTestHelper.appendStringToFile(directory.toPath(), "file1.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory.toPath(), "file2.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory.toPath(), "file3.txt", "Test\n");
+        addAndCommit(git);
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            GitHelper.exportDiff(git, os);
+            assertTrue(os.toByteArray().length > 0);
+        }
+
+        FileTestHelper.appendStringToFile(directory.toPath(), "file1.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory.toPath(), "file2.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory.toPath(), "file3.txt", "Test\n");
+        addAndCommit(git);
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            GitHelper.exportDiff(git, os);
+            assertTrue(os.toByteArray().length > 0);
+        }
+    }
+
+    @Test
+    public void exportDiffOnEmptyFiles() throws Exception {
+        addAndCommit(git);
+        //
+        File newFile = new File(directory, "testfile.txt");
+        FileUtils.createNewFile(newFile);
+        assertTrue(newFile.length() == 0);
+        addAndCommit(git);
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            GitHelper.exportDiff(git, os);
+            //System.out.println(os.toString());
+        }
+    }
+
+    @Test
+    public void applyPatch() throws Exception {
+        File directory1 = folder.newFolder();
+        File directory2 = folder.newFolder();
+
+        Git git1 = Git.init().setDirectory(directory1).call();
+        addAndCommit(git1);
+
+        Git git2 = Git.init().setDirectory(directory2).call();
+        addAndCommit(git2);
+
+        FileTestHelper.appendStringToFile(directory1.toPath(), "file1.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory1.toPath(), "file2.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory1.toPath(), "file3.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory2.toPath(), "file1.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory2.toPath(), "file2.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory2.toPath(), "file3.txt", "Test\n");
+
+        addAndCommit(git1);
+        addAndCommit(git2);
+
+        FileTestHelper.appendStringToFile(directory1.toPath(), "file1.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory1.toPath(), "file2.txt", "Test\n");
+        FileTestHelper.appendStringToFile(directory1.toPath(), "file3.txt", "Test\n");
+
+        addAndCommit(git1);
+
+        byte[] diff;
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            GitHelper.exportDiff(git1, os);
+            diff = os.toByteArray();
+        }
+
+        try (ByteArrayInputStream is = new ByteArrayInputStream(diff)) {
+            GitHelper.applyDiff(git2, is);
+        }
+
+        assertTrue(FileTestHelper.isDirectoryEqualsWithoutGit(directory1.toPath(), directory2.toPath()));
+    }
+}

--- a/src/test/java/tdl/record/sourcecode/snapshot/helpers/JGitUnsupportedDiffAlgoIssueTest.java
+++ b/src/test/java/tdl/record/sourcecode/snapshot/helpers/JGitUnsupportedDiffAlgoIssueTest.java
@@ -9,23 +9,46 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import tdl.record.sourcecode.test.FileTestHelper;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.assertTrue;
 import static tdl.record.sourcecode.snapshot.helpers.GitHelper.addAndCommit;
 
-public class DiffAlgoPatienceJGitIssueTest {
+@RunWith(Parameterized.class)
+public class JGitUnsupportedDiffAlgoIssueTest {
 
     private File directory;
     private Git git;
+    private final String diffAlgorithm;
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                { "patience" },
+                { "myers" },
+                { "histogram" },
+                { "xxxx" },
+                { "" },
+                { " " },
+                { null },
+        });
+    }
+
+    public JGitUnsupportedDiffAlgoIssueTest(String diffAlgorithm) {
+        this.diffAlgorithm = diffAlgorithm;
+    }
 
     @Before
     public void setup() throws IOException, GitAPIException {
@@ -36,7 +59,7 @@ public class DiffAlgoPatienceJGitIssueTest {
             ConfigConstants.CONFIG_DIFF_SECTION,
             null,
             ConfigConstants.CONFIG_KEY_ALGORITHM,
-            "patience");
+                diffAlgorithm);
     }
 
     @Test


### PR DESCRIPTION
Fix applied to issue #22 

When local or global git config is set to use a diff algorithm unsupported by JGit, dev-sourcecode-record fails with an error, during diff related operations

This fix takes care of falling back to `histogram` when unsupported algorithms are passed in via the git config:

```
patience
xxx
[empty setting]
[space]
[null]
```